### PR TITLE
Add warn mode option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.0.8
+VERSION=0.0.9
 LDFLAGS=-ldflags "-X main.Version=${VERSION}"
 GO111MODULE=on
 

--- a/diff-detector.go
+++ b/diff-detector.go
@@ -19,7 +19,7 @@ type options struct {
 	OptArgs       []string
 	OptCommand    string
 	OptIdentifier string `long:"identifier" arg:"String" description:"indetify a file store the command result with given string"`
-	OptWarn       bool   `long:"warning" description:"Set the error level to warning"`
+	OptWarn       bool   `short:"w" long:"warn" description:"Set the error level to warning"`
 }
 
 func runCmd(curFile *os.File, opts *options) error {

--- a/diff-detector.go
+++ b/diff-detector.go
@@ -19,6 +19,7 @@ type options struct {
 	OptArgs       []string
 	OptCommand    string
 	OptIdentifier string `long:"identifier" arg:"String" description:"indetify a file store the command result with given string"`
+	OptWarn       bool   `long:"warning" description:"Set the error level to warning"`
 }
 
 func runCmd(curFile *os.File, opts *options) error {
@@ -164,7 +165,11 @@ func _main() (st int) {
 		} else {
 			fmt.Printf("NG: detect difference: ```%s```\n", diffRetString)
 		}
-		st = 2
+		if opts.OptWarn {
+			st = 1
+		} else {
+			st = 2
+		}
 	} else {
 		fmt.Printf("Error: %s\n", diffError)
 	}


### PR DESCRIPTION
## What

* add --warn (-w) option which return 1 (warn) when there is diff: which can suppress notification

## example

```
taka-h@C02CM6FJMD6T diff-detector % ./diff-detector -w -- cat date.txt                                            add-warn-mode-option
Notice: first time execution command: 'cat date.txt'
taka-h@C02CM6FJMD6T diff-detector % ./diff-detector -w -- cat date.txt                                            add-warn-mode-option
OK: no difference: ```Thu Nov 26 23:30:08 JST 2020```

: warn mode
taka-h@C02CM6FJMD6T diff-detector % echo $(date) > date.txt                                                       add-warn-mode-option
taka-h@C02CM6FJMD6T diff-detector % ./diff-detector -w -- cat date.txt                                            add-warn-mode-option
NG: detect difference: ```@@ -1 +1 @@
-Thu Nov 26 23:30:08 JST 2020
+Thu Nov 26 23:33:08 JST 2020```
taka-h@C02CM6FJMD6T diff-detector % echo $?                                                                       add-warn-mode-option
1

: with no option (default)
taka-h@C02CM6FJMD6T diff-detector % echo $(date) > date.txt                                                       add-warn-mode-option
taka-h@C02CM6FJMD6T diff-detector % ./diff-detector -- cat date.txt                                               add-warn-mode-option
NG: detect difference: ```@@ -1 +1 @@
-Thu Nov 26 23:33:08 JST 2020
+Thu Nov 26 23:33:36 JST 2020```
taka-h@C02CM6FJMD6T diff-detector % echo $?                                                                       add-warn-mode-option
2
```

## Note

exit status for custom checks
https://mackerel.io/ja/docs/entry/custom-checks


終了ステータス | 意味
-- | --
0 | OK
1 | WARNING
2 | CRITICAL
0,1,2以外 | UNKNOWN

